### PR TITLE
Allow jupyterhub-githubauth to be hosted on Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM jupyterhub/jupyterhub:0.6.1
+FROM jupyterhub/jupyterhub:0.7.2
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN pip install -U pip
 RUN pip install dockerspawner==0.7.0
-RUN pip install https://github.com/IDR/oauthenticator/archive/0.5.1-IDR1.zip
+# TODO: Fork and tag kubespawner (last pypi release is too old)
+RUN pip install https://github.com/jupyterhub/kubespawner/archive/master.zip
+RUN pip install https://github.com/IDR/oauthenticator/archive/0.5.1-IDR2.zip
+RUN pip install jupyterhub-dummyauthenticator
 
 RUN useradd user
 ADD run.sh /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN pip install -U pip
 RUN pip install dockerspawner==0.7.0
-# TODO: Fork and tag kubespawner (last pypi release is too old)
-RUN pip install https://github.com/jupyterhub/kubespawner/archive/master.zip
+# TODO: Use upstream pypi release when it's updated
+RUN pip install https://github.com/IDR/kubespawner/archive/0.5.2-IDR1.zip
 RUN pip install https://github.com/IDR/oauthenticator/archive/0.5.1-IDR2.zip
 RUN pip install jupyterhub-dummyauthenticator
 


### PR DESCRIPTION
Switching back from [running on Jupyterhub on the host](https://github.com/IDR/ansible-role-idr-jupyter/pull/3) to running in docker (via Kubernetes)