### PR TITLE
Check IDR_OMERO_CONFIGURATION_URL env var for auto-configuration (IDR-0.4.4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install -U pip
 RUN pip install dockerspawner==0.7.0
 # TODO: Use upstream pypi release when it's updated
 RUN pip install https://github.com/IDR/kubespawner/archive/0.5.2-IDR1.zip
-RUN pip install https://github.com/IDR/oauthenticator/archive/0.5.1-IDR2.zip
+RUN pip install https://github.com/IDR/oauthenticator/archive/0.5.1-IDR3.zip
 RUN pip install jupyterhub-dummyauthenticator
 
 ADD https://raw.githubusercontent.com/jupyterhub/jupyterhub/0.7.2/examples/cull-idle/cull_idle_servers.py /srv/jupyterhub/

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -117,11 +117,10 @@ c.GitHubOAuthenticator.client_secret_hostmap = json.loads(os.getenv('IDR_JUPYTER
 
 
 ######################################################################
-# IDR internal connection settings
+# IDR connection settings
 ######################################################################
 
-c.Spawner.environment = {
-    'IDR_HOSTNAME': os.getenv('IDR_HOSTNAME'),
-    'IDR_USER': os.getenv('IDR_USER'),
-    'IDR_PASSWORD': os.getenv('IDR_PASSWORD'),
-}
+c.Spawner.environment = {}
+for name in ('OMERO_CONFIGURATION_URL', 'HOST', 'PORT', 'USER', 'PASSWORD'):
+    if os.getenv('IDR_' + name):
+        c.Spawner.environment['IDR_' + name] = os.getenv('IDR_' + name)


### PR DESCRIPTION
Updates the environment passed to notebooks:
- Added `IDR_OMERO_CONFIGURATION_URL`
- Added `IDR_PORT`
- Renamed `IDR_HOSTNAME` to `IDR_HOST`

See
- https://github.com/IDR/idr-notebooks/pull/39
- https://github.com/bramalingam/idr-py/pull/1